### PR TITLE
provide a hook so that the overlay behind the WMS scenes can be accessed

### DIFF
--- a/leaflet.wms.js
+++ b/leaflet.wms.js
@@ -371,6 +371,9 @@ wms.Overlay = L.Layer.extend({
                 this.options.opacity ? this.options.opacity : 1
             );
         }
+
+        // Save the overlay so that it can be accessed by the outside world.
+        this.overlay = overlay;
     },
 
     // See L.TileLayer.WMS: onAdd() & getTileUrl()


### PR DESCRIPTION
@lukecampbell, I don't have permission to self-merge.  And this bad boy is necessary for WMS opacities to respond to opacity sliders.

After you merge this, we'll need to point OM's bower.json to this new SHA.
