### PR TITLE
only update params if something has changed

### DIFF
--- a/src/leaflet.wms.js
+++ b/src/leaflet.wms.js
@@ -337,8 +337,12 @@ wms.Overlay = L.Layer.extend({
     },
 
     'setParams': function(params) {
-        L.extend(this.wmsParams, params);
-        this.update();
+        var newParams = L.extend({}, this.wmsParams, params);
+        // Only update params if something has changed or we don't have underscorejs.
+        if (!(_ && _.isEqual(newParams, this.wmsParams))) {
+          this.wmsParams = newParams;
+          this.update();
+        }
     },
 
     'getAttribution': function() {


### PR DESCRIPTION
@Bobfrat This is a low level to check to prevent WMS layers from updating is no params have been changed.  (We're already rolling our own leaflet.wms branch for OM.)